### PR TITLE
Remove EMSI Dependency and Allocator use

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -3,9 +3,6 @@
     "description": "Library for parsing randomly formatted date strings",
     "license": "BSL-1.0",
     "authors": ["Jack Stouffer"],
-    "dependencies": {
-        "emsi_containers": "~>0.8.0"
-    },
     "configurations": [
         {
             "name": "library",


### PR DESCRIPTION
This PR removes the use of the emsi container dependency
and the allocator.
This makes the code faster to compile and I couldn't measure
and performance difference.
The array/vector is very small after all anyway.